### PR TITLE
added null value check when adding headers

### DIFF
--- a/EvHttpSharp/EventHttpRequest.cs
+++ b/EvHttpSharp/EventHttpRequest.cs
@@ -62,7 +62,8 @@ namespace EvHttpSharp
             var pHeaders = Event.EvHttpRequestGetOutputHeaders(_handle);
             foreach (var header in headers)
                 if (header.Key != "Content-Length")
-                    Event.EvHttpAddHeader(pHeaders, header.Key, header.Value);
+                    if (header.Value != null)
+                        Event.EvHttpAddHeader(pHeaders, header.Key, header.Value);
 
             Event.EvHttpAddHeader(pHeaders, "Content-Length", CalculateLength(body).ToString());
             var buffer = Event.EvBufferNew();


### PR DESCRIPTION
Null header values were causing me problems here. Although I should fix this upstream too, I think evhttp-sharp should ignore them rather than throw an AccessViolationException, as it currently does under Windows at least.
