### PR TITLE
Make headers better conform to OWIN specification

### DIFF
--- a/EvHttpSharp.OwinHost/EvOwinListener.cs
+++ b/EvHttpSharp.OwinHost/EvOwinListener.cs
@@ -30,7 +30,7 @@ namespace EvHttpSharp.OwinHost
                 {
                     var env = new Dictionary<string, object>();
                     env["owin.RequestBody"] = new MemoryStream(req.RequestBody);
-                    env["owin.RequestHeaders"] = req.Headers.ToDictionary(x => x.Key, x => x.Value.ToArray());
+                    env["owin.RequestHeaders"] = req.Headers.ToDictionary(x => x.Key, x => x.Value.ToArray(), StringComparer.OrdinalIgnoreCase);
                     env["owin.RequestMethod"] = req.Method;
 
                     var pairs = req.Uri.Split(new[] { '?' }, 2);


### PR DESCRIPTION
The OWIN specification notes this about the implementation of the IDictionary<string, string[]>  containing the headers, 

> Keys MUST be compared using StringComparer.OrdinalIgnoreCase.

http://owin.org/html/owin.html

Not implementing this behavior can cause issues for many OWIN integrations as they assume they can compare the fields of the IDictionary as if they were case insensitive. 
